### PR TITLE
Errors in amelidiate output function call

### DIFF
--- a/R/amelidiate.R
+++ b/R/amelidiate.R
@@ -28,6 +28,7 @@ amelidiate<-function(g){
             model.y<-k$model.y
             model.m<-k$model.m
             boot=k$boot
+            boot.ci.type=k$boot.ci.type
             treat=k$treat
             mediator=k$mediator
             nobs<-k$nobs
@@ -85,13 +86,13 @@ amelidiate<-function(g){
 
     d1.ci <- cis$d1.sims
     d0.ci <- cis$d0.sims
-    d.avg.ci<-cis$d.avg
+    d.avg.ci<-cis$d.sims
 
     tau.ci <- cis$tau.sims
 
     z1.ci <- cis$z1.sims
     z0.ci <- cis$z0.sims
-    z.avg.ci<-cis$z.avg
+    z.avg.ci<-cis$z.sims
 
     n.avg.ci<-cis$n.avg
     n1.ci<-cis$n1.sims
@@ -147,7 +148,7 @@ amelidiate<-function(g){
                         d.avg.ci=d.avg.ci,z.avg.ci=z.avg.ci,n.avg.ci=n.avg.ci,
                         d0.p=d0.p, d1.p=d1.p,z1.p=z1.p,
                         z0.p=z0.p,tau.p=tau.p,n0.p=n0.p,n1.p=n1.p,d.avg.p=d.avg.p,z.avg.p=z.avg.p,n.avg.p=n.avg.p,
-                        INT=INT, boot=boot,
+                        INT=INT, boot=boot, boot.ci.type=boot.ci.type,
                         model.y=model.y, model.m=model.m)
 
     class(out) <- "mediate"


### PR DESCRIPTION
1. Running summary() resulted in error saying 'boot.ci.type' was empty:
 - Added to input from the object, then exported in the final output returned
2. Error in the calculation of the confidence intervals whereby the ACME (average) and ADE (average) CIs were the same as the estimate
 - Changed the *.avg.ci for d & z to utilise *.sims rather than *.avg objects - output CIs are now symmetric about the estimate