### PR TITLE
Use na.omit() over sort() for clarity

### DIFF
--- a/R/mediate.R
+++ b/R/mediate.R
@@ -742,7 +742,7 @@ mediate <- function(model.m, model.y, sims = 1000,
     } else{
       n <- n.m
     }
-    m <- length(sort(unique(model.frame(model.m)[,1])))
+    m <- length(na.omit(unique(model.frame(model.m)[,1])))
   }
   
   # Extracting weights from models


### PR DESCRIPTION
`sort()` looks redundant here because we're just taking the `length()` of the output -- why bother?

But actually, `sort()` _does_ have one somewhat invisible side-effect: dropping missing observations:

```r
sort(c(1, 2, NA))
# [1] 1 2
```

Readers of the code can easily miss that; switching to `na.omit()` instead makes this much more obvious.

Thankfully, we already import that name from {stats}:

https://github.com/kosukeimai/mediation/blob/a9a5c7b747b1d96d9a6df7b7cfe3d7719a1b0780/NAMESPACE#L97